### PR TITLE
Boolean where fix

### DIFF
--- a/lib/ql.js
+++ b/lib/ql.js
@@ -973,7 +973,7 @@ class QL {
     let args = [rlt, op];
     if (isObject(key)) {
       args = [value, rlt];
-    } else if (value) {
+    } else if (value || value === false) {
       data = {};
       data[key] = value;
     }

--- a/test/ql.js
+++ b/test/ql.js
@@ -165,6 +165,21 @@ describe('influxdb-ql', () => {
     ql.where({});
     assert.equal(ql.toSelect(), 'select * from "mydb".."http"');
   });
+  it('where({path: false})', () => {
+    const ql = new QL('mydb');
+    ql.measurement = 'http';
+    ql.where('path', false);
+    console.log("SELECT", ql.toSelect());
+    assert.equal(ql.toSelect(), 'select * from "mydb".."http" where "path" = false');
+  });
+  it('where({path: true})', () => {
+    const ql = new QL('mydb');
+    ql.measurement = 'http';
+    ql.where({
+      path: true
+    });
+    assert.equal(ql.toSelect(), 'select * from "mydb".."http" where "path" = true');
+  });
 
   it('call where twice', () => {
     const ql = new QL('mydb');


### PR DESCRIPTION
if provided false as a where condition to a query the parameter would not be set and only the field specified.

This causes issues with queries generated as such
```sql
select * from "mydb".."http" where path
// instead of 
select * from "mydb".."http" where "path" = false
```

This pull request will fix the issue, test cases included