### PR TITLE
Remove conditions/groups/fields sorting

### DIFF
--- a/lib/ql.js
+++ b/lib/ql.js
@@ -234,11 +234,11 @@ function getQL(data) {
 
   if (conditions.length) {
     const joinKey = ` ${data.relation} `;
-    arr.push(`where ${conditions.sort().join(joinKey)}`);
+    arr.push(`where ${conditions.join(joinKey)}`);
   }
 
   if (groups && groups.length) {
-    arr.push(`group by ${groups.sort().map(convertGroupValue).join(',')}`);
+    arr.push(`group by ${groups.map(convertGroupValue).join(',')}`);
 
     if (!isNil(data.fill)) {
       arr.push(`fill(${data.fill})`);
@@ -1279,7 +1279,7 @@ class QL {
         .forEach(items => selectFields.push.apply(selectFields, items));
     }
     if (selectFields.length) {
-      arr.push(selectFields.sort().join(','));
+      arr.push(selectFields.join(','));
     } else {
       arr.push('*');
     }


### PR DESCRIPTION
Sorting affects the order of conditions, and it's can have a significant impact on query performance